### PR TITLE
Add support for zone tags

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.terraform
+terraform*

--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ module "forward-zone" {
 | force\_destroy | (Optional, Default:false) A boolean that indicates all domains should be deleted from the zone so it can be destroyed without error. | string | `"false"` | no |
 | forward\_domain | Domain to forward. Must be the fully qualified domain name. | string | n/a | yes |
 | root\_domain | Domain containing the subdomain to forward. | string | n/a | yes |
+| tags | (Optional, Default: {}) A map of tags to be added to the zone created. | map | `<map>` | no |
 | ttl | (Optional, Default:600) TTL for the NS records to be created. | string | `"600"` | no |
 
 ## Outputs
@@ -44,3 +45,4 @@ module "forward-zone" {
 |------|-------------|
 | name\_servers | Nameservers for the new, child route53 zone |
 | zone\_id | ID of the new, child route53 zone |
+

--- a/main.tf
+++ b/main.tf
@@ -13,6 +13,7 @@ data "aws_route53_zone" "root" {
 resource "aws_route53_zone" "main" {
   name          = "${var.forward_domain}"
   force_destroy = "${var.force_destroy}"
+  tags          = "${var.tags}"
 }
 
 resource "aws_route53_record" "forward" {

--- a/variables.tf
+++ b/variables.tf
@@ -18,3 +18,10 @@ variable "force_destroy" {
   description = "(Optional, Default:false) A boolean that indicates all domains should be deleted from the zone so it can be destroyed without error."
   default     = "false"
 }
+
+variable "tags" {
+  description = "(Optional, Default: {}) A map of tags to be added to the zone created."
+  default = {
+    Managed = "terraform"
+  }
+}


### PR DESCRIPTION
Zone tags allow for better discoverability for dynamically generated records, or when zones are configured in separate plans.